### PR TITLE
robust ActiveRecord check

### DIFF
--- a/lib/schema_plus/foreign_keys/middleware/sql.rb
+++ b/lib/schema_plus/foreign_keys/middleware/sql.rb
@@ -4,7 +4,7 @@ module SchemaPlus::ForeignKeys
       module Table
         def after(env)
           foreign_keys = case 
-                         when Gem::Requirement.new('~> 4.2.0').satisfied_by?(::ActiveRecord.version) then env.table_definition.foreign_keys
+                         when Gem::Requirement.new('4.2.0').satisfied_by?(::ActiveRecord.version) then env.table_definition.foreign_keys
                          else env.table_definition.foreign_keys.values.tap { |v| v.flatten! }
                          end
 

--- a/lib/schema_plus/foreign_keys/middleware/sql.rb
+++ b/lib/schema_plus/foreign_keys/middleware/sql.rb
@@ -3,8 +3,8 @@ module SchemaPlus::ForeignKeys
     module Sql
       module Table
         def after(env)
-          foreign_keys = case ::ActiveRecord.version
-                         when Gem::Version.new("4.2.0") then env.table_definition.foreign_keys
+          foreign_keys = case 
+                         when Gem::Requirement.new('~> 4.2.0').satisfied_by?(::ActiveRecord.version) then env.table_definition.foreign_keys
                          else env.table_definition.foreign_keys.values.tap { |v| v.flatten! }
                          end
 


### PR DESCRIPTION
My company’s Rails app has problems with schema_plus on ActiveRecord version `4.2.6`. The foreign key Gem version check is modified for checking AR `4.2.0`
