### PR TITLE
Add support for Rails 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ gemfile:
 - gemfiles/activerecord-5.0/Gemfile.mysql2
 - gemfiles/activerecord-5.0/Gemfile.postgresql
 - gemfiles/activerecord-5.0/Gemfile.sqlite3
+- gemfiles/activerecord-5.1/Gemfile.mysql2
+- gemfiles/activerecord-5.1/Gemfile.postgresql
+- gemfiles/activerecord-5.1/Gemfile.sqlite3
 env: POSTGRESQL_DB_USER=postgres MYSQL_DB_USER=travis
 addons:
   postgresql: '9.4'

--- a/README.md
+++ b/README.md
@@ -145,11 +145,13 @@ SchemaPlus::ForeignKeys is tested on:
 * ruby **2.3.1** with activerecord **4.2.1**, using **mysql2**, **sqlite3** or **postgresql**
 * ruby **2.3.1** with activerecord **4.2.6**, using **mysql2**, **sqlite3** or **postgresql**
 * ruby **2.3.1** with activerecord **5.0**, using **mysql2**, **sqlite3** or **postgresql**
+* ruby **2.3.1** with activerecord **5.1**, using **mysql2**, **sqlite3** or **postgresql**
 
 <!-- SCHEMA_DEV: MATRIX - end -->
 
 ## History
 
+* 0.1.8 - Compatibility with ActiveRecord 5.1.
 * 0.1.7 - Compatibility with ActiveRecord 5.0.
 * 0.1.6 - Missing require
 * 0.1.5 - Explicit gem dependencies

--- a/gemfiles/activerecord-5.1/Gemfile.base
+++ b/gemfiles/activerecord-5.1/Gemfile.base
@@ -1,0 +1,3 @@
+eval File.read File.expand_path('../../Gemfile.base', __FILE__)
+
+gem "activerecord", "~> 5.1.0"

--- a/gemfiles/activerecord-5.1/Gemfile.mysql2
+++ b/gemfiles/activerecord-5.1/Gemfile.mysql2
@@ -1,0 +1,10 @@
+require "pathname"
+eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
+
+platform :ruby do
+  gem "mysql2"
+end
+
+platform :jruby do
+  gem 'activerecord-jdbcmysql-adapter'
+end

--- a/gemfiles/activerecord-5.1/Gemfile.postgresql
+++ b/gemfiles/activerecord-5.1/Gemfile.postgresql
@@ -1,0 +1,10 @@
+require "pathname"
+eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
+
+platform :ruby do
+  gem "pg"
+end
+
+platform :jruby do
+  gem 'activerecord-jdbcpostgresql-adapter'
+end

--- a/gemfiles/activerecord-5.1/Gemfile.sqlite3
+++ b/gemfiles/activerecord-5.1/Gemfile.sqlite3
@@ -1,0 +1,10 @@
+require "pathname"
+eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
+
+platform :ruby do
+  gem "sqlite3"
+end
+
+platform :jruby do
+  gem 'activerecord-jdbcsqlite3-adapter', '>=1.3.0.beta2'
+end

--- a/lib/schema_plus/foreign_keys/version.rb
+++ b/lib/schema_plus/foreign_keys/version.rb
@@ -1,5 +1,5 @@
 module SchemaPlus
   module ForeignKeys
-    VERSION = "0.1.7"
+    VERSION = "0.1.8"
   end
 end

--- a/schema_dev.yml
+++ b/schema_dev.yml
@@ -5,6 +5,7 @@ activerecord:
     - 4.2.1
     - 4.2.6
     - 5.0
+    - 5.1
 db:
     - mysql2
     - sqlite3

--- a/schema_plus_foreign_keys.gemspec
+++ b/schema_plus_foreign_keys.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "activerecord", ">= 4.2", "< 5.1"
+  gem.add_dependency "activerecord", ">= 4.2", "< 5.2"
   gem.add_dependency "schema_plus_core"
   gem.add_dependency "schema_plus_compatibility", "~> 0.2"
   gem.add_dependency "valuable"


### PR DESCRIPTION
No big changes really. Just added Gemfiles for Rails 5.1 so it can be tested. We're depending on https://github.com/SchemaPlus/schema_auto_foreign_keys which I would like add rails 5.1 support to also. But before I can do that we need to add it here first (since schema_auto_foreign_keys depend on this gem) :smile: 